### PR TITLE
Fix parameter destructuring in Courses layout

### DIFF
--- a/app/(Kambaz)/Courses/[cid]/layout.tsx
+++ b/app/(Kambaz)/Courses/[cid]/layout.tsx
@@ -2,7 +2,8 @@ import { ReactNode } from "react";
 import CourseNavigation from "./Navigation";
 export default async function CoursesLayout(
   { children, params }: Readonly<{ children: ReactNode; params: Promise<{ id: string }> }>) {
- const { cid } = await params;
+//  const { cid } = await params;
+const { id: cid } = await params;
  return (
    <div id="wd-courses">
      <h2>Courses {cid}</h2>


### PR DESCRIPTION
Corrects the destructuring of the 'params' object to use 'id' as 'cid' instead of 'cid' directly. This ensures the course ID is displayed properly in the layout.