### PR TITLE
Fix parameter destructuring in Courses layout v2

### DIFF
--- a/app/(Kambaz)/Courses/[cid]/layout.tsx
+++ b/app/(Kambaz)/Courses/[cid]/layout.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from "react";
 import CourseNavigation from "./Navigation";
 export default async function CoursesLayout(
-  { children, params }: Readonly<{ children: ReactNode; params: Promise<{ id: string }> }>) {
-//  const { cid } = await params;
-const { id: cid } = await params;
+  { children, params }: Readonly<{ children: ReactNode; params: Promise<{ cid: string }> }>) {
+ const { cid } = await params;
+// const { id: cid } = await params;
  return (
    <div id="wd-courses">
      <h2>Courses {cid}</h2>


### PR DESCRIPTION
Updated the CoursesLayout component to destructure 'cid' from params instead of 'id', ensuring the correct course identifier is used.