### PR TITLE
Add heading with name and course info to Lab1 page

### DIFF
--- a/app/(Kambaz)/Labs/Lab1/page.tsx
+++ b/app/(Kambaz)/Labs/Lab1/page.tsx
@@ -3,6 +3,7 @@
 export default function Lab1() {
   return (
     <div id="wd-lab1">
+        <h1>Murtaza Nipplewala CS5610 Section 4</h1>
       <h2>Lab 1</h2>
       <h3>HTML Examples</h3>
       <div id="wd-h-tag">


### PR DESCRIPTION
Inserted an <h1> element displaying 'Murtaza Nipplewala CS5610 Section 4' at the top of the Lab1 page for identification and context.